### PR TITLE
Tip for getting json response instead of HTML

### DIFF
--- a/middleware/error-handling.md
+++ b/middleware/error-handling.md
@@ -22,6 +22,9 @@ app.use(error({
     }
 }))
 ```
+
+> **ProTip:** If you want to have the response in json format be sure to set the `Accept` header in your request to `application/json` otherwise the default error handler will return HTML.
+
 ## Options
 
 The following options can be passed when creating a new localstorage service:


### PR DESCRIPTION
While prototyping, first thing most devs do is fire postman or curl and start hitting the rest api and might not know that they need to set `Accept: application/json` for feathers to send a json response.

https://github.com/feathersjs/feathers-mongoose/issues/56
https://feathersjs.slack.com/archives/general/p1457449015000948