### PR TITLE
Fixing wrong method name in sample code

### DIFF
--- a/authorization/bundled-hooks.md
+++ b/authorization/bundled-hooks.md
@@ -163,7 +163,7 @@ const hooks = require('feathers-authentication').hooks;
 
 app.service('messages').before({
   remove: [
-    hooks.restrictToOwner({
+    hooks.restrictToRoles({
         roles: ['admin', 'super-admin'],
         fieldName: 'permissions',
         idField: 'id',


### PR DESCRIPTION
Sample code for `restrictToRoles` uses wrong method name (i.e. `restrictedToOwner`) instead of `restrictToRoles`.