### PR TITLE
Change feathers-client to npmcdn.com with version range

### DIFF
--- a/authentication/client.md
+++ b/authentication/client.md
@@ -43,7 +43,7 @@ Then you pass whatever other fields you need to send to authenticate. See below 
 
 ```html
 <script src="//code.jquery.com/jquery-1.12.0.min.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js"></script>
+<script type="text/javascript" src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
 <script type="text/javascript">
   var host = 'http://localhost:3030';
 
@@ -85,7 +85,7 @@ let app = feathers()
 
 ```html
 <script type="text/javascript" src="/socket.io/socket.io.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js"></script>
+<script type="text/javascript" src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
 <script type="text/javascript">
   // Set up socket.io
   var host = 'http://localhost:3030';
@@ -126,7 +126,7 @@ let app = feathers()
 
 ```html
 <script type="text/javascript" src="/primus/primus.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js"></script>
+<script type="text/javascript" src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
 <script type="text/javascript">
   // Set up primus
   var host = 'http://localhost:3030';

--- a/clients/feathers.md
+++ b/clients/feathers.md
@@ -60,7 +60,7 @@ In the browser a client that connects to the local server via websockets can be 
 
 ```html
 <script type="text/javascript" src="socket.io/socket.io.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js"></script>
+<script type="text/javascript" src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
 <script type="text/javascript">
   var socket = io('http://api.my-feathers-server.com');
   var app = feathers()

--- a/clients/rest.md
+++ b/clients/rest.md
@@ -79,7 +79,7 @@ Using [the Feathers client](feathers.md), the `feathers-rest/client` module can 
 
 ```html
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/superagent/1.2.0/superagent.min.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js"></script>
+<script type="text/javascript" src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
 <script type="text/javascript">
   const rest = feathers.rest('http://api.feathersjs.com');
   const app = feathers()

--- a/clients/socket-io.md
+++ b/clients/socket-io.md
@@ -14,7 +14,7 @@ Using [the Feathers client](feathers.md), the `feathers-socketio/client` module 
 
 ```html
 <script type="text/javascript" src="socket.io/socket.io.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js"></script>
+<script type="text/javascript" src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
 <script type="text/javascript">
   var socket = io('http://api.feathersjs.com');
   var app = feathers()

--- a/getting-started/scaffolding.md
+++ b/getting-started/scaffolding.md
@@ -90,7 +90,7 @@ You can also connect to the real-time API using [Socket.io](../real-time/socket-
 Add the following to `public/index.html` before the `</body>` tag:
 
 ```html
-<script src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js"></script>
+<script src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
 <script src="socket.io/socket.io.js"></script>
 <script type="text/javascript">
   // Establish a Socket.io connection to the local server

--- a/guides/jquery.md
+++ b/guides/jquery.md
@@ -61,7 +61,7 @@ The first step is getting the HTML skeleton for the chat application up. You can
     <script src="//code.jquery.com/jquery-2.2.1.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.12.0/moment.js">
     </script>
-    <script src="//cdn.rawgit.com/feathersjs/feathers-client/v1.0.0/dist/feathers.js">
+    <script src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js">
     </script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="app.js"></script>

--- a/guides/react.md
+++ b/guides/react.md
@@ -25,7 +25,7 @@ React and the Feathers client modules can be loaded individually via [npm](https
     <script src="//fb.me/react-dom-0.14.7.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.12.0/moment.js"></script>
-    <script src="//rawgit.com/feathersjs/feathers-client/master/dist/feathers.js"></script>
+    <script src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script type="text/babel" src="app.jsx"></script>
   </head>


### PR DESCRIPTION
This switches the docs to use feathers-client from npmcdn.com. This is a great change because it supports SemVer version ranges (like https://npmcdn.com/feathers-client@^1.0.0/dist/feathers.js) and we don't need to check in the distributables anymore.

@ekryski Can we change this on the homepage Gists as well?

Closes #120