### PR TITLE
Fixed broken Services link in API chapter

### DIFF
--- a/api/readme.md
+++ b/api/readme.md
@@ -1,6 +1,6 @@
 # API
 
-Feathers core API is very small and an initialized application provides the same functionality as an [Express 4](http://expressjs.com/en/4x/api.html) application. The differences and additional methods and their usage are outlined in this chapter. For the service API refer to the [Services chapter](services.html).
+Feathers core API is very small and an initialized application provides the same functionality as an [Express 4](http://expressjs.com/en/4x/api.html) application. The differences and additional methods and their usage are outlined in this chapter. For the service API refer to the [Services chapter](../services/readme.md).
 
 ## configure
 


### PR DESCRIPTION
Not sure how to test this correctly, but I tried to follow existing links I found in other chapters.