### PR TITLE
Lowercase default client-side header

### DIFF
--- a/authentication/readme.md
+++ b/authentication/readme.md
@@ -115,7 +115,7 @@ app.authenticate({
 
 - `tokenEndpoint` (default: '/auth/token') [optional] - The JWT auth service endpoint.
 - `localEndpoint` (default: '/auth/local') [optional] - The local auth service endpoint
-- `header` (default: 'Authorization') [optional] - The header field to set the token. **This is case sensitive**.
+- `header` (default: 'authorization') [optional] - The header field to set the token. **This is case sensitive**.
 - `cookie` (default: 'feathers-jwt') [optional] - The cookie field to check for the token. **This is case sensitive**.
 - `tokenKey` (default: 'feathers-jwt') [optional] - The key to use to store the JWT in localStorage. **This is case sensitive**.
 


### PR DESCRIPTION
This is a quick patch to update the default header value in client-side authentication configuration from `Authorization` to `authorization`. This change was made in feathersjs/feathers-authentication/pull/219 with the intent of normalizing the server- and client-side header defaults which should make the authentication module a little bit easier to use for anyone communicating with it over HTTP.

Blocked by feathersjs/feathers-authentication/pull/219.