### PR TITLE
Brought Community Plug-Ins listing up-to-date with NPM

### DIFF
--- a/why/showcase.md
+++ b/why/showcase.md
@@ -10,13 +10,81 @@ Below are some of the amazing things built with Feathers or for the Feathers eco
 ## Community Plug-ins
 
 Submit yours by creating a pull request.
-- [A populate hook that supports multiple 1:m, m:1 and m:m relations](https://github.com/MichaelErmer/feathers-populate-hook)
-- [A generic validation hook](https://github.com/kulakowka/feathers-validate-hook)
-- [A generic validation hook using Joi](https://github.com/eddyystop/feathers-hooks-validate-joi)
-- [A generic hook for adding virtual attributes](https://github.com/kulakowka/feathers-virtual-attribute-hook)
-- [Some useful hooks](https://github.com/eddyystop/feathers-hooks-common)
-- [Add email verification and password reset capabilities to local feathers-authentication](https://github.com/eddyystop/feathers-service-verify-reset)
 
+#### Authentication
+- [feathers-accounts](https://www.npmjs.com/package/feathers-accounts) - Token-Based User Account System for FeathersJS (configure)
+- [feathers-service-verify-reset](https://www.npmjs.com/package/feathers-service-verify-reset) - Adds user email verification and password reset capabilities to local feathers-authentication (service)
+
+#### Communications
+- [feathers-batch](https://www.npmjs.com/package/feathers-batch) - Batch multiple Feathers service calls into one (service)
+
+#### Database
+- [amity-mongodb](https://www.npmjs.com/package/amity-mongodb) - Use various FeatherJS services to manage a MongoDB server with Amity.
+- [can-connect-feathers](https://www.npmjs.com/package/can-connect-feathers) - Feathers client library for DoneJS and can-connect (feathers-client)
+- [canjs-feathers](https://www.npmjs.com/package/canjs-feathers) - CanJS model implementation that connects to Feathers services through feathers-client. (feathers-client)
+- [feathers-blob](https://www.npmjs.com/package/feathers-blob) - Feathers abstract blob store service (service)
+- [feathers-blueprints](https://www.npmjs.com/package/feathers-blueprints) - Add some of the Sails.js blueprints functionality to Feathers. (configure)
+- [feathers-bookshelf](https://www.npmjs.com/package/feathers-bookshelf) - A bookshelf ORM service adapter.  (service)
+- [feathers-connect](https://www.npmjs.com/package/feathers-connect) - Feathers client library for DoneJS and can-connect (feathers-client)
+- [feathers-filemaker](https://www.npmjs.com/package/feathers-filemaker) - Filemaker adapter for feathers.js
+- [feathers-linvodb](https://www.npmjs.com/package/feathers-linvodb) - Create an LinvoDB Service for FeatherJS. (service)
+- [feathers-mongo-collections](https://www.npmjs.com/package/feathers-mongo-collections) - MongoDB collections service for FeathersJS. (service)
+- [feathers-mongo-databases](https://www.npmjs.com/package/feathers-mongo-databases) - Create a MongoDB database service for FeathersJS. (service)
+- [feathers-mongodb-revisions](https://www.npmjs.com/package/feathers-mongodb-revisions) - This Feathers database adapter extends the basic MongoDB adapter, adding revision support. (service)
+- [feathers-mongoose-advanced](https://www.npmjs.com/package/feathers-mongoose-advanced) - Create a flexible Mongoose Service for FeathersJS. (service)
+- [feathers-mongoose-service](https://www.npmjs.com/package/feathers-mongoose-service) - Easily create a Mongoose Service for Featherjs. (service)
+- [feathers-nedb-dump](https://www.npmjs.com/package/feathers-nedb-dump) - Middleware for Feathers.js - dumps and restores NeDB database for a given service (middleware)
+- [feathers-orm-service](https://www.npmjs.com/package/feathers-orm-service) - Easily create a Object Relational Mapping Service for Featherjs.
+- [feathers-rethinky](https://www.npmjs.com/package/feathers-rethinky) - Thinky.js RethinkDB Adaptor for Feathers JS
+- [feathers-seeder](https://www.npmjs.com/package/feathers-seeder) - Straightforward data seeder for FeathersJS services.
+- [feathers-skypager](https://www.npmjs.com/package/feathers-skypager) - A skypager ORM service adapter (service)
+- [feathers-solr](https://www.npmjs.com/package/feathers-solr) - Solr Adapter for Feathersjs
+
+#### Documentation
+- [feathers-swagger](https://www.npmjs.com/package/feathers-swagger) - Add documentation to your Featherjs services and feed them to Swagger UI. (configure)
+
+#### Multiple instances
+- [feathers-cluster](https://www.npmjs.com/package/feathers-cluster) - Easily take advantage of multi-core systems for Featherjs. (configure)
+- [feathers-sync](https://www.npmjs.com/package/feathers-sync) - Synchronize service events between application instances using MongoDB publish/subscribe (configure)
+
+#### Email
+- [feathers-mailer](https://www.npmjs.com/package/feathers-mailer) - Feathers mailer service using nodemailer (service)
+- [feathers-mailgun](https://www.npmjs.com/package/feathers-mailgun) - A Mailgun Service for FeatherJS. (service)
+- [feathers-sendgrid](https://www.npmjs.com/package/feathers-sendgrid) - A SendGrid Service for FeatherJS. (service)
+
+#### React, Redux
+- [feathers-action](https://www.npmjs.com/package/feathers-action) - use feathers services with redux (connector)
+- [feathers-action-creators](https://www.npmjs.com/package/feathers-action-creators) - redux action creators for feathers services
+- [feathers-action-reducer](https://www.npmjs.com/package/feathers-action-reducer) - redux reducer for feathers service actions
+- [feathers-action-types](https://www.npmjs.com/package/feathers-action-types) - flux action types for feathers services (connector)
+- [feathers-react-redux](https://www.npmjs.com/package/feathers-react-redux) - Unofficial Feathers bindings for React-Redux.
+
+#### Testing
+- [feathers-tests-fake-app-users](https://www.npmjs.com/package/feathers-tests-fake-app-users) - Fake some feathers dependencies in service unit tests. Starter for your customized fakes (service)
+
+#### Transformation
+- [feathers-populate-hook](https://www.npmjs.com/package/feathers-populate-hook) - Feathers hook to populate multiple fields with n:m, n:1 or 1:m relations. (hook)
+- [feathers-transform-hook](https://www.npmjs.com/package/feathers-transform-hook) - Feathers hook for transform hook.data parameters (hook)
+- [feathers-virtual-attribute-hook](https://www.npmjs.com/package/feathers-virtual-attribute-hook) - Feathers hook for add virtual attributes to your service response (hook)
+
+#### Utilities
+- [feathers-hooks-common](https://www.npmjs.com/package/feathers-hooks-common) - Useful hooks for use with Feathersjs services. (hooks)
+- [feathers-hooks-utils](https://www.npmjs.com/package/feathers-hooks-utils) - Utility library for writing Feathersjs hooks. (hooks)
+
+#### Validation
+- [feathers-hooks-validate-joi](https://www.npmjs.com/package/feathers-hooks-validate-joi) - Feathers hook utility for schema validation, sanitization and client notification using Joi. (hook)
+- [feathers-hook-validation-jsonschema](https://www.npmjs.com/package/feathers-hook-validation-jsonschema) - Validate Feathers resources using JSON Schema. (hook)
+- [feathers-tcomb](https://www.npmjs.com/package/feathers-tcomb) - validate feathers services using tcomb (app.service)
+- [feathers-validate-hook](https://www.npmjs.com/package/feathers-validate-hook) - Feathers hook for validate json-schema with is-my-json-valid (hook)
+- [feathers-validator](https://www.npmjs.com/package/feathers-validator) - A validator for Feathers services. (service)
+
+#### View layer
+- [donejs-feathers](https://www.npmjs.com/package/donejs-feathers) - A generator to quickly add FeathersJS to your DoneJS project. Includes Auth! (generator)
+- [feathers-done-ssr](https://www.npmjs.com/package/feathers-done-ssr) - a set of Express middleware that allows Feathers JWT tokens to work with DoneJS's built-in SSR.
+- [feathers-mithril](https://www.npmjs.com/package/feathers-mithril) - Connect feathers.js to mithril.js (connector)
+- [feathers-reactive](https://www.npmjs.com/package/feathers-reactive) - Turns a Feathers service call into an RxJS observables that automatically updates on real-time events. (configure)
+- [ng-feathers](https://www.npmjs.com/package/ng-feathers) - Feathers client for AngularJS. FeatherJS for plain old AngularJS (1.X)
+- [vue-syncers-feathjers](https://www.npmjs.com/package/vue-syncers-feathers) - Synchronises feathers services with vue objects, updated in real time (connector)
 
 ## Examples or Tutorials
 


### PR DESCRIPTION
I went through Feathers-related packages on NPM to get an idea of what was available. I updated the Community Plug-Ins doc with what I found. I tried not to include Featherjs packages mentioned within the docs, e.g. feathers-nedb.

The packages listed are of variable quality, so you might decide not to pull this.