### PR TITLE
Change messages to message

### DIFF
--- a/getting-started/user-management.md
+++ b/getting-started/user-management.md
@@ -226,7 +226,7 @@ After stopping (CTRL + C) and starting the server (`npm start`) again we can go 
 
 ## Authorization
 
-Now that we can authenticate we want to restrict the Message service to only authenticated users. We could have done that already in the service generator by answering _"yes"_ when asked if we need authentication but we can also easily add it manually by changing `src/services/messages/hooks/index.js` to:
+Now that we can authenticate we want to restrict the Message service to only authenticated users. We could have done that already in the service generator by answering _"yes"_ when asked if we need authentication but we can also easily add it manually by changing `src/services/message/hooks/index.js` to:
 
 ```js
 'use strict';


### PR DESCRIPTION
This tutorial instructs us to create a service called message, yet it shows the folder name for this service as messages. I changed the name to message.  There is another tutorial that uses the name messages, but not this one.