### PR TITLE
Missing line in hook code at this juncture of Your First App.

### DIFF
--- a/getting-started/user-management.md
+++ b/getting-started/user-management.md
@@ -232,6 +232,7 @@ Now that we can authenticate we want to restrict the Message service to only aut
 'use strict';
 
 const globalHooks = require('../../../hooks');
+const hooks = require('feathers-hooks');
 const auth = require('feathers-authentication').hooks;
 
 exports.before = {


### PR DESCRIPTION
Following the docs in `Your First App` very closely, in `User Management ~ Authorization` section, the code in `services/messages/hooks/index.js` contains this extra line, added here.

To clarify, `services/messages/hooks/index.js` presents with this extra line when the student first opens the file.