### PR TITLE
More (simple) examples of using built-in operands

### DIFF
--- a/clients/vanilla-rest.md
+++ b/clients/vanilla-rest.md
@@ -18,6 +18,18 @@ GET /messages?status=read&user=10
 
 Will call `messages.find({ query: { status: 'read', user: '10' } })` on the server.
 
+If you want to use any of the built-in find operands ($le, $lt, $ne, $eq, $in, etc.) the general format is as follows:
+
+```
+GET /messages?field[$operand]=value[,value2,value3,...]
+```
+
+For example, to find the records where field _status_ is not equal to **active** you could do
+
+```
+GET /messages?status[$ne]=active
+```
+
 ### get
 
 Retrieve a single resource from the service.


### PR DESCRIPTION
After being totally confused as how to use operands like $le, $gt, $ne, etc. within a standard URL type GET request, decided to add a couple of examples to give people a basic idea.