### PR TITLE
[Events] Add 'Event Listener Lifecycle' section

### DIFF
--- a/real-time/events.md
+++ b/real-time/events.md
@@ -125,6 +125,20 @@ Now clients can listen to the `<servicepath> status` event. Custom events can be
 
 It is easy to listen for these events on the client or the server. Depending on the socket library you are using it is a bit different so refer to either the [Socket.io](socket-io.md) or [Primus](primus.md) docs.
 
+## Event Listener Lifecycle
+
+Registered event listeners can be unregistered through the `removeListener('eventName', listener)` api.
+
+```js
+const messages = app.service('messages');
+
+function onCreatedListener(message) {
+  console.log('created', message);
+}
+
+messages.on('created', onCreatedListener);
+messages.removeListener('created', onCreatedListener);
+```
 
 ## Hooks vs Events
 


### PR DESCRIPTION
I ran into a situation in React where I had to register and unregister an event listener. I was familiar with the registering api (`service.on(...)`), but I didn't know about `service.removeListener(...)` until I got some help from @ekryski.

I figured it'd probably be good to have this in the docs.