### PR TITLE
Use correct ico file

### DIFF
--- a/getting-started/user-management.md
+++ b/getting-started/user-management.md
@@ -113,8 +113,7 @@ Finally, `public/signup.html` looks like this:
     <meta name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=0">
     <title>Feathers Chat</title>
-
-    <link rel="shortcut icon" href="img/favicon.png">
+    <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="//cdn.rawgit.com/feathersjs/feathers-chat/v0.1.0/public/base.css">
     <link rel="stylesheet" href="//cdn.rawgit.com/feathersjs/feathers-chat/v0.1.0/public/chat.css">
   </head>


### PR DESCRIPTION
The image is not included in the generated template, and returns a 404.

It is also now consistent with the other html files.