### PR TITLE
correct 'remove' hook notation

### DIFF
--- a/hooks/common.md
+++ b/hooks/common.md
@@ -88,7 +88,7 @@ and then `fieldName` will be set to the service object(s) selected.
 
 
 ### remove
-`remove(fieldName: string, ...fieldNames?: string[]): HookFunc`
+`remove(fieldName: string [, fieldName: string,...]): HookFunc`
 
 Remove the given fields either from the data submitted or from the result. If the data is an array or a paginated `find` result the hook will remove the field(s) for every item.
 


### PR DESCRIPTION
It seems the current notation means that you should pass string and then an optional array of strings.