### PR TITLE
Typo fix in setUpdatedAt hook

### DIFF
--- a/hooks/common.md
+++ b/hooks/common.md
@@ -214,7 +214,7 @@ const hooks = require('feathers-hooks-common');
 
 // set the `updatedAt` field before a user is created
 app.service('users').before({
-  create: [ hooks.setCreatedAt('updatedAt') ]
+  create: [ hooks.setUpdatedAt('updatedAt') ]
 };
 ```
 


### PR DESCRIPTION
Small typo when using the `setUpdatedAt` hook, which was shown as `setCreatedAt`.