### PR TITLE
Fixed description of verifyChanges field in authentication management

### DIFF
--- a/authentication/management.md
+++ b/authentication/management.md
@@ -435,7 +435,7 @@ You should add them to your user model if your database uses models.
   isVerified: { type: Boolean },
   verifyToken: { type: String },
   verifyExpires: { type: Date }, // or a long integer
-  verifyChanges: // an array of strings
+  verifyChanges: // an object (key-value map), e.g. { field: "value" }
   resetToken: { type: String },
   resetExpires: { type: Date }, // or a long integer
 }


### PR DESCRIPTION
Just a small change, but I lost a lot of time because I've set `verifyChanges` field type to array of strings in my Sequelize/Postgres model and it didn't work at all. After looking over the source code I realized it does not use array of strings, but a key-value map. Setting column type to JSON solved the problem, but I think that description in docs is confusing, so I decided to create this PR.
