### PR TITLE
Socket.io-client dependency import

### DIFF
--- a/clients/feathers.md
+++ b/clients/feathers.md
@@ -59,7 +59,7 @@ Then in the main application file:
 
 ```js
 import 'babel-polyfill';
-import io from 'socket.io-client/socket.io';
+import io from 'socket.io-client';
 import feathers from 'feathers/client';
 import socketio from 'feathers-socketio/client';
 import hooks from 'feathers-hooks';


### PR DESCRIPTION
Change `import io from 'socket.io-client/socket.io';` to `import io from 'socket.io-client';` as otherwise there's an error when importing the dependency. (At least from what I have been encountering when switching our app from rest client to socket client).

It's used as described in [official repo](https://github.com/socketio/socket.io-client#nodejs-server-side-usage) too.