### PR TITLE
Rename service from 'messages' to 'message'

### DIFF
--- a/getting-started/quick-start.md
+++ b/getting-started/quick-start.md
@@ -33,7 +33,7 @@ With [NodeJS](https://nodejs.org) installed, you can quickly scaffold your first
     $ feathers generate
     ```
 
-4. Generate a new service. When asked `What do you want to call your service?`, type `messages` and confirm the other prompts with the default:
+4. Generate a new service. When asked `What do you want to call your service?`, type `message` and confirm the other prompts with the default:
 
     ```
     $ feathers generate service


### PR DESCRIPTION
The scaffolding section of the tutorial expects the service to be named 'message', not 'messages'.