### PR TITLE
Fixing some typos in the DB section

### DIFF
--- a/api/application.md
+++ b/api/application.md
@@ -1,6 +1,6 @@
 # API
 
-Feathers core API is very small and an initialized application provides the same functionality as an [Express 4](http://expressjs.com/en/4x/api.html) application. The differences and additional methods and their usage are outlined in this chapter. For the service API refer to the [Services chapter](../services/readme.md).
+The Feathers core API is very small and an initialized application provides the same functionality as an [Express 4](http://expressjs.com/en/4x/api.html) application. The differences and additional methods and their usage are outlined in this chapter. For the service API refer to the [Services chapter](../services/readme.md).
 
 ## configure
 
@@ -8,7 +8,7 @@ Feathers core API is very small and an initialized application provides the same
 
 ```js
 function setupService() {
-    this.use('/todos', todoService);
+  this.use('/todos', todoService);
 }
 
 app.configure(setupService);
@@ -34,13 +34,13 @@ Normally `app.setup` will be called automatically when starting the application 
 // Serve public folder for everybody
 app.use(feathers.static(__dirname + '/public');
 // Make sure that everything else only works with authentication
-app.use(function(req,res,next){
-  if(req.isAuthenticated()){
-    next();
-  } else {
-    // 401 Not Authorized
-    next(new Error(401));
+app.use(function(req, res, next) {
+  if (req.isAuthenticated()) {
+    return next();
   }
+
+  // 401 Not Authorized
+  next(new Error(401));
 });
 // Add a service.
 app.use('/todos', {
@@ -69,7 +69,7 @@ app.use('/my/todos', {
 var todoService = app.service('my/todos');
 // todoService is an event emitter
 todoService.on('created', todo => 
-    console.log('Created todo', todo)
+  console.log('Created todo', todo)
 );
 ```
 

--- a/api/databases/common.md
+++ b/api/databases/common.md
@@ -8,7 +8,7 @@ All database adapters implement a common interface for initialization, paginatio
 
 ### `service([options])`
 
-Returns a new service instance intitialized with the given options.
+Returns a new service instance initialized with the given options.
 
 ```js
 const service = require('feathers-<adaptername>');
@@ -55,13 +55,14 @@ app.use('/todos', service({
   }
 }));
 
-// override pagination in `params.paginate`
+// override pagination in `params.paginate` for this call
 app.service('todos').find({
   paginate: {
     default: 100,
     max: 200
   }
 });
+
 // disable pagination for this call
 app.service('todos').find({
   paginate: false
@@ -254,13 +255,13 @@ const app = feathers()
 
 app.service('todos').hooks({
   before: {
-    create(hook) {
-      hook.data.createdAt = new Date();
-    },
+    create: [
+      (hook) => hook.data.createdAt = new Date()
+    ],
     
-    update(hook) {
-      hook.data.updatedAt = new Date();
-    }
+    update: [
+      (hook) => hook.data.updatedAt = new Date()
+    ]
   }
 });
 

--- a/api/databases/knexjs.md
+++ b/api/databases/knexjs.md
@@ -18,7 +18,7 @@ npm install --save mysql knex feathers-knex
 
 ### `service(options)`
 
-Returns a new service instance intitialized with the given options.
+Returns a new service instance initialized with the given options.
 
 ```js
 const knex = require('knex');

--- a/api/databases/localstorage.md
+++ b/api/databases/localstorage.md
@@ -17,7 +17,7 @@ $ npm install --save feathers-localstorage
 
 ### `service(options)`
 
-Returns a new service instance intitialized with the given options.
+Returns a new service instance initialized with the given options.
 
 ```js
 const service = require('feathers-localstorage');

--- a/api/databases/memory.md
+++ b/api/databases/memory.md
@@ -17,7 +17,7 @@ $ npm install --save feathers-memory
 
 ### `service([options])`
 
-Returns a new service instance intitialized with the given options.
+Returns a new service instance initialized with the given options.
 
 ```js
 const service = require('feathers-memory');

--- a/api/databases/mongodb.md
+++ b/api/databases/mongodb.md
@@ -19,7 +19,7 @@ $ npm install --save mongodb feathers-mongodb
 
 ### `service(options)`
 
-Returns a new service instance intitialized with the given options. `Model` has to be a MongoDB collection.
+Returns a new service instance initialized with the given options. `Model` has to be a MongoDB collection.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;

--- a/api/databases/mongoose.md
+++ b/api/databases/mongoose.md
@@ -19,7 +19,7 @@ $ npm install --save mongoose feathers-mongoose
 
 ### `service(options)`
 
-Returns a new service instance intitialized with the given options. `Model` has to be a Mongoose model. See the [Mongoose Guide](http://mongoosejs.com/docs/guide.html) for more information on defining your model.
+Returns a new service instance initialized with the given options. `Model` has to be a Mongoose model. See the [Mongoose Guide](http://mongoosejs.com/docs/guide.html) for more information on defining your model.
 
 ```js
 const mongoose = require('mongoose');
@@ -50,7 +50,7 @@ __Options:__
 
 <!-- -->
 
-> **Important:** Whe setting `lean` to `false`, Mongoose models will be returned which can not be modified unless they are converted via `toObject`.
+> **Important:** When setting `lean` to `false`, Mongoose models will be returned which can not be modified unless they are converted to a regular JavaScript object via `toObject`.
 
 <!-- -->
 

--- a/api/databases/nedb.md
+++ b/api/databases/nedb.md
@@ -16,7 +16,7 @@ $ npm install --save nedb feathers-nedb
 
 ### `service(options)`
 
-Returns a new service instance intitialized with the given options. `Model` has to be an NeDB database instance.
+Returns a new service instance initialized with the given options. `Model` has to be an NeDB database instance.
 
 ```js
 const NeDB = require('nedb');

--- a/api/databases/rethinkdb.md
+++ b/api/databases/rethinkdb.md
@@ -18,7 +18,7 @@ $ npm install --save rethinkdbdash feathers-rethinkdb
 
 ### `service(options)`
 
-Returns a new service instance intitialized with the given options. For more information on initializing the driver see the [RehinktDBdash documentation](https://github.com/neumino/rethinkdbdash).
+Returns a new service instance initialized with the given options. For more information on initializing the driver see the [RehinktDBdash documentation](https://github.com/neumino/rethinkdbdash).
 
 ```js
 const r = require('rethinkdbdash')({
@@ -113,7 +113,7 @@ var app = feathers()
   }))
   .use(errorHandler());
 
-// Intitialize database and messages table if it does not exists yet
+// Initialize database and messages table if it does not exists yet
 app.service('messages').init().then(() => {
   // Create a message on the server
   app.service('messages').create({

--- a/api/databases/sequelize.md
+++ b/api/databases/sequelize.md
@@ -28,7 +28,7 @@ npm install --save tedious // MSSQL
 
 ### `service(options)`
 
-Returns a new service instance intitialized with the given options.
+Returns a new service instance initialized with the given options.
 
 ```js
 const Model = require('./models/mymodel');


### PR DESCRIPTION
Also making all the hook examples (where applicable) the array style syntax. I did this for 2 reasons:

1. To be more consistent
2. Because that is what the generator ships like and might reduce confusion for people.