### PR TITLE
Removed socket.io from supported in primus

### DIFF
--- a/real-time/readme.md
+++ b/real-time/readme.md
@@ -9,6 +9,6 @@ With Feathers websockets aren't just used for sending events from server to clie
 Currently Feathers supports two websocket transport libraries:
 
 - [Socket.io](socket-io.md) - Probably the most commonly used real-time library for NodeJS. It works on every platform, browser or device, focusing equally on reliability and speed.
-- [Primus](primus.md) - Is a universal wrapper for real-time frameworks that supports Engine.IO, WebSockets, Faye, BrowserChannel, SockJS and Socket.IO
+- [Primus](primus.md) - Is a universal wrapper for real-time frameworks that supports BrowserChannel, Engine.IO, Faye, SockJS, uws and WebSockets.
 
 In this chapter we will look at how to use [Service events](events.md), how to configure the [Socket.io](socket-io.md) and [Primus](primus.md) real-time libraries and about how to [restrict sending events to specific clients](filtering.md).


### PR DESCRIPTION
Regarding to https://github.com/primus/primus#supported-real-time-frameworks Primus doesn't support socket.io anymore.