### PR TITLE
Auk framework guides

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,6 +29,7 @@
     * [Adding authentication](guides/chat/authentication.md)
     * [Processing data](guides/chat/processing.md)
     * [Frameworks: React, Vue etc.](guides/chat/frameworks.md)
+  * [Frontend Frameworks](guides/frameworks/readme.md)
   * [Debugging](guides/debug/readme.md)
 * [API](api/readme.md)
   * Core

--- a/guides/frameworks/readme.md
+++ b/guides/frameworks/readme.md
@@ -1,0 +1,19 @@
+# Integrating with Frontend Frameworks
+
+## Feathers Chat Applications
+These guides show how to integrate the [Feathers Chat application](guides/chat/readme.md) with various frontend frameworks.
+
+[**Feathers Chat - React**]()<br/>
+Not yet published on the blog.
+
+[**Feathers Chat - Vue.js 2**]()<br/>
+Not yet published on the blog.
+
+[**Feathers Chat - Vue.js 2 with `feathers-vuex`**]()<br/>
+Not yet published on the blog.
+
+
+## Vue.js
+
+[**Integrating Nuxt into your Feathers Application**](https://blog.feathersjs.com/ssr-vuejs-app-with-feathers-and-nuxt-bb7dfd3e6397)<br/>
+Learn how to integrate the Nuxt server-side rendering framework for Vue.js into your Feathers application.

--- a/guides/readme.md
+++ b/guides/readme.md
@@ -8,3 +8,6 @@ This is the original Feathers chat application guide, re-written for the latest 
 
 [**Frontend Frameworks**](./frameworks/readme.md)<br/>
 A curated collection of guides created by the FeathersJS team and members of the Feathers community.
+
+[**Debugging**](./debug/readme.md)<br/>
+Techniques, tips, and tricks on how to debug your Feathers applications.

--- a/guides/readme.md
+++ b/guides/readme.md
@@ -5,3 +5,6 @@ The goal of this guide is to get you to the "A-ha!" moment as efficiently as pos
 
 [**A Chat Application**](./chat/readme.md)<br/>
 This is the original Feathers chat application guide, re-written for the latest release.  You'll learn how to add authentication to an application.
+
+[**Frontend Frameworks**](./frameworks/readme.md)<br/>
+A curated collection of guides created by the FeathersJS team and members of the Feathers community.


### PR DESCRIPTION
This starts a page where we can keep track of framework guides and add them as they become available.  I've left placeholders for the guides that we already have.  I don't think we need to wait to merge this, though.