### PR TITLE
Added feathers-reduxify-services to frontend adapters.

### DIFF
--- a/guides/chat/frameworks.md
+++ b/guides/chat/frameworks.md
@@ -12,6 +12,10 @@ Not yet published on the blog.
 [**Feathers Chat - Vue.js 2 with `feathers-vuex`**]()<br/>
 Not yet published on the blog.
 
+## React's Redux
+
+[Integrate Feathers services with Redux](https://github.com/eddyystop/feathers-reduxify-services)<br/>
+Wrap Feathers services so they work transparently with Redux.
 
 ## Vue.js
 


### PR DESCRIPTION
feathers-reduxify-services is to Redux like the already listed feathers-vuex is to Vue.

Since its a 3-rd party repo, Feathers isn't responsible for maintaining it.