### PR TITLE
Fixing old or broken links

### DIFF
--- a/api/authentication/oauth1.md
+++ b/api/authentication/oauth1.md
@@ -2,7 +2,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/feathersjs/feathers-authentication-oauth1.png?style=social&label=Star)](https://github.com/feathersjs/feathers-authentication-oauth1/)
 [![npm version](https://img.shields.io/npm/v/feathers-authentication-oauth1.png?style=flat-square)](https://www.npmjs.com/package/feathers-authentication-oauth1)
-[![Changelog](https://img.shields.io/badge/changelog-.md-blue.png?style=flat-square)](https://github.com/feathersjs/feathers-authentication-oauth1/blob/master/CHANGELOG.md)
+<!--- [![Changelog](https://img.shields.io/badge/changelog-.md-blue.png?style=flat-square)](https://github.com/feathersjs/feathers-authentication-oauth1/blob/master/CHANGELOG.md) --->
 
 ```
 $ npm install feathers-authentication-oauth1 --save

--- a/api/authentication/oauth2.md
+++ b/api/authentication/oauth2.md
@@ -2,7 +2,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/feathersjs/feathers-authentication-oauth2.png?style=social&label=Star)](https://github.com/feathersjs/feathers-authentication-oauth2/)
 [![npm version](https://img.shields.io/npm/v/feathers-authentication-oauth2.png?style=flat-square)](https://www.npmjs.com/package/feathers-authentication-oauth2)
-[![Changelog](https://img.shields.io/badge/changelog-.md-blue.png?style=flat-square)](https://github.com/feathersjs/feathers-authentication-oauth2/blob/master/CHANGELOG.md)
+<!--- [![Changelog](https://img.shields.io/badge/changelog-.md-blue.png?style=flat-square)](https://github.com/feathersjs/feathers-authentication-oauth2/blob/master/CHANGELOG.md) --->
 
 ```
 $ npm install feathers-authentication-oauth2 --save

--- a/api/authentication/server.md
+++ b/api/authentication/server.md
@@ -23,8 +23,7 @@ The following plugins are complementary, but entirely optional:
 - [feathers-authentication-jwt](./jwt.md)
 - [feathers-authentication-oauth1](./oauth1.md)
 - [feathers-authentication-oauth2](./oauth2.md)
-- [feathers-permissions](./permissions.md)
-
+- [feathers-permissions](https://github.com/feathersjs/feathers-permissions) 
 ## API
 
 This module contains:
@@ -163,7 +162,7 @@ Additional middleware are included and exposed but typically you don't need to w
 Refer to [the migration guide](https://github.com/feathersjs/feathers-authentication/blob/master/docs/migrating.md).
 
 ## Complete Example
-Here's an example of a Feathers server that uses `feathers-authentication` for local auth. You can try it out on your own machine by running the [example](./example/).
+Here's an example of a Feathers server that uses `feathers-authentication` for local auth. You can try it out on your own machine by running the [example](https://github.com/feathersjs/feathers-authentication/tree/master/example)
 
 **Note:** This example does NOT implement any authorization. Use [feathers-permissions](https://github.com/feathersjs/feathers-permissions) for that.
 

--- a/api/databases/elasticsearch.md
+++ b/api/databases/elasticsearch.md
@@ -110,7 +110,7 @@ query: {
 ```
 
 ### $match
-[Full text query `match`]((https://https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html). Find all documents which have given given fields matching the specified value (analysed).
+[Full text query `match`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html). Find all documents which have given given fields matching the specified value (analysed).
 
 ```js
 query: {

--- a/api/databases/knexjs.md
+++ b/api/databases/knexjs.md
@@ -166,7 +166,7 @@ Through the REST API:
 
 In a `find` call, `params.knex` can be passed a KnexJS query (without pagination) to customize the find results.
 
-Combined with `.createQuery(query)`, which returns a new KnexJS query with the [common filter criteria](./querying.md) applied, this can be used to create more complex queries. The best way to customize the query is in a [before hook](../hooks/index.md) for `find`.
+Combined with `.createQuery(query)`, which returns a new KnexJS query with the [common filter criteria](./querying.md) applied, this can be used to create more complex queries. The best way to customize the query is in a [before hook](../hooks.md) for `find`.
 
 ```js
 app.service('mesages').hooks({

--- a/api/databases/localstorage.md
+++ b/api/databases/localstorage.md
@@ -35,7 +35,7 @@ __Options:__
 - `startId` (*optional*, default: `0`) - An id number to start with that will be incremented for new record.
 - `name` (*optional*, default: `'feathers'`) - The key to store data under in local or async storage.
 - `store` (*optional*) - An object with id to item assignments to pre-initialize the data store
-- `paginate` (*optional*) - A [pagination object](./pagination.md) containing a `default` and `max` page size
+- `paginate` (*optional*) - A [pagination object](common.md#pagination) containing a `default` and `max` page size
 
 
 ## Example

--- a/api/databases/memory.md
+++ b/api/databases/memory.md
@@ -31,7 +31,7 @@ __Options:__
 - `id` (*optional*, default: `'id'`) - The name of the id field property.
 - `startId` (*optional*, default: `0`) - An id number to start with that will be incremented for every new record (unless it is already set).
 - `store` (*optional*) - An object with id to item assignments to pre-initialize the data store
-- `events` (*optional*) - A list of [custom service events](../real-time/events.md#custom-events) sent by this service
+- `events` (*optional*) - A list of [custom service events](../events.md#custom-events) sent by this service
 - `paginate` (*optional*) - A [pagination object](./pagination.md) containing a `default` and `max` page size
 
 

--- a/api/databases/mongoose.md
+++ b/api/databases/mongoose.md
@@ -54,11 +54,11 @@ __Options:__
 
 <!-- -->
 
-> **Note:** You can get access to the Mongoose model via `this.Model` inside a [hook](../hooks/readme.md) and use it as usual. See the [Mongoose Guide](http://mongoosejs.com/docs/guide.html) for more information on defining your model.
+> **Note:** You can get access to the Mongoose model via `this.Model` inside a [hook](../hooks.md) and use it as usual. See the [Mongoose Guide](http://mongoosejs.com/docs/guide.html) for more information on defining your model.
 
 ### params.mongoose
 
-When making a [service method](./services.md) call, `params` can contain an `mongoose` property which allows to modify the options used to run the Mongoose query. Normally this wil be set in a before [hook](./hooks.md):
+When making a [service method](../services.md) call, `params` can contain an `mongoose` property which allows to modify the options used to run the Mongoose query. Normally this wil be set in a before [hook](../hooks.md):
 
 ```js
 app.service('messages').hooks({

--- a/api/databases/querying.md
+++ b/api/databases/querying.md
@@ -40,7 +40,7 @@ app.service('messages').find({
 GET /messages?$limit=2&read=false
 ```
 
-> **Pro tip:** With [pagination enabled](../common.md#pagination), to just get the number of available records set `$limit` to `0`. This will only run a (fast) counting query against the database and return a page object with the `total` and an empty `data` array.
+> **Pro tip:** With [pagination enabled](common.md#pagination), to just get the number of available records set `$limit` to `0`. This will only run a (fast) counting query against the database and return a page object with the `total` and an empty `data` array.
 
 ## `$skip`
 

--- a/api/databases/rethinkdb.md
+++ b/api/databases/rethinkdb.md
@@ -217,4 +217,4 @@ app.service('mesages').hooks({
 
 `.createQuery(query)` can also be used to listen to changefeeds and then send [custom events](../real-time/events.md).
 
-Since the service already sends real-time events for all changes the recommended way to listen to changes is with [feathers-reactive](../ecosystem/feathers-reactive.md) however.
+Since the service already sends real-time events for all changes the recommended way to listen to changes is with [feathers-reactive](../../ecosystem/readme.md#client--framework-integration) however.

--- a/api/events.md
+++ b/api/events.md
@@ -43,7 +43,7 @@ messages.emit('customEvent', {
 
 ## Service Events
 
-Any service automaticaly emits `created`, `updated`, `patched` and `removed` events when the respective service method returns successfully. This works on the client as well as on the server. When the client is using [Socket.io](./socketio.md) or [Primus](./primus.md), events will be pushed automatically from the server to all connected client. This is essentially how Feathers does real-time.
+Any service automaticaly emits `created`, `updated`, `patched` and `removed` events when the respective service method returns successfully. This works on the client as well as on the server. When the client is using [Socket.io](socketio.md) or [Primus](primus.md), events will be pushed automatically from the server to all connected client. This is essentially how Feathers does real-time.
 
 > **ProTip:** Events are not fired until all of your [hooks](./hooks.md) have executed.
 
@@ -251,4 +251,4 @@ class PaymentService {
 }
 ```
 
-Now clients can listen to the `<servicepath> status` event. Custom events can be [filtered](filtering.md) just like standard events.
+Now clients can listen to the `<servicepath> status` event. Custom events can be [filtered](#event-filtering) just like standard events.

--- a/api/express.md
+++ b/api/express.md
@@ -4,7 +4,7 @@ On the server, a Feathers application acts as a drop-in replacement for any [Exp
 
 > **Important:** This chapter assumes that you are familiar with [Express](http://expressjs.com/en/guide/routing.html).
 
-
+<!---->
 ## Setting service `params`
 
 All middleware registered after the [REST transport](./rest.md) will have access to the `req.feathers` object to set properties on the service method `params`:
@@ -135,7 +135,8 @@ function updateData(req, res, next) {
 }
 ```
 
-Keep in mind that shared authentication (between REST and websockets) should use a service based approach as described in the [authentication configuration](./authentication/configuration.md).
+Keep in mind that shared authentication (between REST and websockets) should use a service based approach as described in the authentication configuration.
+<!--- Missing link to authentication configuration guide --->
 
 Information about how to use a custom formatter (e.g. to send something other than JSON) can be found in the [REST transport](./rest.md) chapter.
 

--- a/ecosystem/readme.md
+++ b/ecosystem/readme.md
@@ -160,7 +160,7 @@ The Feathers client works with React Native but here is a collection of native l
 - [feathers-hooks](../api/hooks.md) ![Official Feathers Module](/img/tiny-feathers-logo.png) 
 - [feathers-hooks-common](../api/hooks-common.md) ![Official Feathers Module](/img/tiny-feathers-logo.png) - Useful hooks for use with Feathersjs services. (hooks) 
 - [feathers-hooks-utils](https://www.npmjs.com/package/feathers-hooks-utils) - Utility library for writing Feathersjs hooks. (hooks)
-- [feathers-logger](./feathers-logger.html) ![Official Feathers Module](/img/tiny-feathers-logo.png) 
+- [feathers-logger](https://github.com/feathersjs/feathers-logger) ![Official Feathers Module](/img/tiny-feathers-logo.png) 
 - [feathers-query-filters](https://github.com/feathersjs/feathers-logger) ![Official Feathers Module](/img/tiny-feathers-logo.png) 
 - [feathers-service-logger-stats](https://github.com/feathersjs/feathers-service-logger-stats) ![Official Feathers Module](/img/tiny-feathers-logo.png) 
 - [feathers-socket-commons](https://github.com/feathersjs/feathers-socket-commons) ![Official Feathers Module](/img/tiny-feathers-logo.png) 

--- a/faq/readme.md
+++ b/faq/readme.md
@@ -242,7 +242,7 @@ function (hook) {
 
 ## How do I debug my app
 
-It's really no different than debugging any other NodeJS app but you can refer to the [Debugging](../guides/advances/debugging.md) section of the guide for more Feathers specific tips and tricks.
+It's really no different than debugging any other NodeJS app but you can refer to the [Debugging](../guides/advanced/debugging.md) section of the guide for more Feathers specific tips and tricks.
 
 ## `possible EventEmitter memory leak detected` warning
 

--- a/guides/advanced/creating-a-plugin.md
+++ b/guides/advanced/creating-a-plugin.md
@@ -154,7 +154,7 @@ export default { coreTeam, bestState };
 
 ```
 
-Now we need to actually write the services. We will only be implementing the find action as you can reference the [service docs](../api/services.md) to learn more. Starting with core-team.js we want to find out the names of the members listed in the feathers.js org on github. 
+Now we need to actually write the services. We will only be implementing the find action as you can reference the [service docs](../../api/services.md) to learn more. Starting with core-team.js we want to find out the names of the members listed in the feathers.js org on github. 
 
 ```js
 //core-team.js

--- a/guides/advanced/using-a-view-engine.md
+++ b/guides/advanced/using-a-view-engine.md
@@ -32,7 +32,7 @@ app.get('/messages', function(req, res, next){
 
 Simple right? We've now rendered a list of messages. All your hooks will get triggered just like they would normally so you can use hooks to pre-filter your data and keep your template rendering routes super tight.
 
-> **ProTip:** If you call a Feathers service "internally" (ie. not over sockets or REST) you won't have a `hook.params.provider` attribute. This allows you to have hooks only execute when services are called externally vs. from your own code. See [bundled hooks](../api/hooks-common.md) for an example.
+> **ProTip:** If you call a Feathers service "internally" (ie. not over sockets or REST) you won't have a `hook.params.provider` attribute. This allows you to have hooks only execute when services are called externally vs. from your own code. See [bundled hooks](../../api/hooks-common.md) for an example.
 
 ## Feathers As A Sub-App
 
@@ -89,4 +89,4 @@ app.get('/messages', function(req, res, next){
 
 > **ProTip:** In the above example we set up sockets. Alternatively you could use a Feathers client [REST provider](../../api/rest.md).
 
-And with that, we've shown 3 different ways that you use a template engine with Feathers to render service data. If you see any issues in this guide feel free to [submit a pull request](https://github.com/feathersjs/feathers-docs/edit/master/guides/server-side-rendering.md).
+And with that, we've shown 3 different ways that you use a template engine with Feathers to render service data. If you see any issues in this guide feel free to [submit a pull request](https://github.com/feathersjs/feathers-docs/edit/master/guides/advanced/using-a-view-engine.md).

--- a/guides/readme.md
+++ b/guides/readme.md
@@ -10,7 +10,7 @@ Learn about Feathers features, philosophy and how it compares with some other fr
 
 The goal of this guide is to get you to the "A-ha!" moment as efficiently as possible.  You will learn how the primary parts of the core work together.  You'll also learn how to start new applications with the generator.
 
-### [The generator (CLI)](./guides/step-by-step/generators/readme.md)
+### [The generator (CLI)](./step-by-step/generators/readme.md)
 
 An overview of the `feathers-cli` and the application it generates.
 

--- a/guides/step-by-step/basic-feathers/real-time.md
+++ b/guides/step-by-step/basic-feathers/real-time.md
@@ -27,7 +27,7 @@ we already have.
 
 ## Working example
 
-- Server code: [examples/step/01/WebSocket/1.js](https://github.com/feathersjs/feathers-docs/blob/master/examples/step/01/WebSocket/1.js)
+- Server code: [examples/step/01/WebSocket/1.js](https://github.com/feathersjs/feathers-docs/blob/master/examples/step/01/websocket/1.js)
 - Listener code: [common/public/listener.html](https://github.com/feathersjs/feathers-docs/blob/master/examples/step/01/common/public/listener.html)
 and
 [listener-app.js](https://github.com/feathersjs/feathers-docs/blob/master/examples/step/01/common/public/listener-app.js)


### PR DESCRIPTION
Removed redundant directory path (guides/guides) to fix link. Thankfully, at present, it only doesn't work rather than directing to 404 though I'm surprised Gitbook parsing didn't throw error. I imagine it assumes you're linking externally to some other md file which is hilariously unlikely if you ask me x)