### PR TITLE
Add a legacy warning to each page

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,30 @@
+{% extends template.self %}
+
+{% block head %}
+  {{ super() }}
+  <style>
+    .legacy-warning {
+      border: none !important;
+      background-color: #ff7d7d;
+    }
+
+    .legacy-warning strong {
+      color: #ccc !important;
+    }
+
+    .legacy-warning a {
+      color: #fff !important;
+    }
+  </style>
+{% endblock %}
+
+{% block page %}
+  <blockquote class="legacy-warning">
+    <p>
+      <strong>Important:</strong>
+      This is the legacy documentation for a previous version of Feathers.<br>
+      For the latest documentation please visit <a href="https://docs.feathersjs.com">docs.feathersjs.com</a>.
+    </p>
+  </blockquote>
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
This adds a legacy deprecation warning to each page of the old docs on https://legacy.docs.feathersjs.com and closes #673:

<img width="880" alt="screen shot 2017-06-10 at 9 50 49 am" src="https://user-images.githubusercontent.com/338316/27004703-bf6987a6-4dc2-11e7-94fa-816267e985de.png">
