### PR TITLE
Update authentication docs to add Direct Usage using sockets

### DIFF
--- a/api/authentication/jwt.md
+++ b/api/authentication/jwt.md
@@ -116,6 +116,8 @@ app.authenticate({
 
 ## Direct Usage
 
+### Using a HTTP Request
+
 If you are not using the `feathers-authentication-client` and you have registered this module server side then you can simply include the access token in an `Authorization` header.
 
 Here is what that looks like with curl:
@@ -123,3 +125,22 @@ Here is what that looks like with curl:
 ```bash
 curl -H "Content-Type: application/json" -H "Authorization: <your access token>" -X POST http://localhost:3030/authentication
 ```
+
+### Using Sockets
+
+Authenticating using an access token via sockets is done by emitting the following message:
+
+```js
+const io = require('socket.io-client');
+const socket = io('http://localhost:3030');
+
+socket.emit('authenticate', {
+  strategy: 'jwt',
+  accessToken: 'your token'
+}, function(message, data) {
+  console.log(message); // message will be null
+  console.log(data); // data will be {"accessToken": "your token"}
+  // You can now send authenticated messages to the server
+});
+```
+

--- a/api/authentication/local.md
+++ b/api/authentication/local.md
@@ -140,6 +140,8 @@ app.authenticate({
 
 ## Direct Usage
 
+### Using a HTTP Request
+
 If you are not using the `feathers-authentication-client` and you have registered this module server side then you can simply make a `POST` request to `/authentication` with the following payload:
 
 ```json
@@ -156,3 +158,23 @@ Here is what that looks like with curl:
 ```bash
 curl -H "Content-Type: application/json" -X POST -d '{"strategy":"local","email":"your email","password":"your password"}' http://localhost:3030/authentication
 ```
+
+### Using Sockets
+
+Authenticating using a local strategy via sockets is done by emitting the following message:
+
+```js
+const io = require('socket.io-client');
+const socket = io('http://localhost:3030');
+
+socket.emit('authenticate', {
+  strategy: 'local',
+  email: 'your email',
+  password: 'your password'
+}, function(message, data) {
+  console.log(message); // message will be null
+  console.log(data); // data will be {"accessToken": "your token"}
+  // You can now send authenticated messages to the server
+});
+```
+


### PR DESCRIPTION
The docs are lacking how to authenticate via sockets without using `feathers-authentication-client`.  Please see this thread inside the `feathers-authentication` repo for more info: https://github.com/feathersjs/feathers-authentication/issues/523#issuecomment-310512114

This PR adds some documentation on how to achieve Local and JWT authentication using plain sockets.