### PR TITLE
Incorrect variable name

### DIFF
--- a/api/databases/sequelize.md
+++ b/api/databases/sequelize.md
@@ -32,7 +32,7 @@ Returns a new service instance initialized with the given options.
 
 ```js
 const Model = require('./models/mymodel');
-const sequelize = service('feathers-sequelize');
+const service = service('feathers-sequelize');
 
 app.use('/messages', service({ Model }));
 app.use('/messages', service({ Model, id, events, paginate }));


### PR DESCRIPTION
Was reading through the example usage with sequelize and noticed that the variable name was incorrectly labelled as `sequelize` when it was obviously meant to be `service`.