### PR TITLE
Missing call to instantiate in example

### DIFF
--- a/api/express.md
+++ b/api/express.md
@@ -10,7 +10,7 @@ On the server, a Feathers application acts as a drop-in replacement for any [Exp
 All middleware registered after the [REST transport](./rest.md) will have access to the `req.feathers` object to set properties on the service method `params`:
 
 ```js
-const app = require('feathers');
+const app = require('feathers')();
 const rest = require('feathers-rest');
 const bodyParser = require('body-parser');
 


### PR DESCRIPTION
Tried to run this example and kept getting an error telling me that `configure` was not a method on `app`. Thought it was related to a change in Express 4.0. Realized that I'm a dummy and that the example code was missing a call to instantiate the app.