### PR TITLE
Disable search engine crawling of legacy docs

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Since there isn't a one-to-one mapping from old to new docs they probably shouldn't show up in search results anymore.