### PR TITLE
Add missing path for registering migration models.

### DIFF
--- a/api/databases/sequelize.md
+++ b/api/databases/sequelize.md
@@ -242,7 +242,7 @@ module.exports = {
 };
 ```
 
-- Register your models. The following assumes you have defined your models using the method [described here](https://github.com/feathersjs/generator-feathers/issues/94#issuecomment-204165134).
+- Register your models in `migrations/models/index.js`. The following assumes you have defined your models using the method [described here](https://github.com/feathersjs/generator-feathers/issues/94#issuecomment-204165134).
 
 ```js
 const Sequelize = require('sequelize');


### PR DESCRIPTION
In the `migrations` section, it says to register the models and then proceeds to give an example which is to be written to file, but it fails mention what to name this file or where it goes in the migrations folder. However in the legacy docs it does. 

This addition merely copies the path given from the legacy docs to the new version, clearing up any confusion as to what to name the file and where to place it in the source.

Cheers :beers:

Scott D.