### PR TITLE
Added missing `feathers-hooks-common` dependency

### DIFF
--- a/examples/offline/package.json
+++ b/examples/offline/package.json
@@ -22,6 +22,7 @@
     "feathers-configuration": "0.4.1",
     "feathers-errors": "2.8.1",
     "feathers-hooks": "2.0.1",
+    "feathers-hooks-common": "3.7.2",
     "feathers-memory": "1.1.0",
     "feathers-nedb": "2.6.2",
     "feathers-offline-publication": "^0.0.2",


### PR DESCRIPTION
The realtime-3 example requires `feathers-hooks-common` to run.