### PR TITLE
Fix link to Angular2 observables tutorial

### DIFF
--- a/ecosystem/readme.md
+++ b/ecosystem/readme.md
@@ -45,7 +45,7 @@ Submit yours by creating a pull request.
 - [Feathers 2 + Vue 2 + Email Verification + Cordova + Framework 7](https://github.com/codingfriend1/Feathers-Vue/tree/cordova)
 - [Feathers + React + Mobx](https://github.com/foxhound87/rfx-stack)
 - [Feathers + React + Webpack](https://github.com/sscaff1/feathers-webpack-react)
-- [Observables with Angular2 and FeathersJS](https://berndsgn.ch/angular2-and-feathersjs)
+- [Observables with Angular2 and FeathersJS](https://berndsgn.ch/observables-with-angular-and-feathersjs/)
 - [Feathers + React + Redux + Webpack + local auth. Production quality](https://github.com/eddyystop/feathers-starter-react-redux-login-roles).
 - [Live query. Mirror part of a DB on the client.](https://github.com/eddyystop/feathers-live-query)
 - [Feathers + React + Redux + Webpack + complete auth + offline mode (ideal for production)](https://github.com/bertho-zero/react-redux-universal-hot-example)


### PR DESCRIPTION
I've updated the link:
https://berndsgn.ch/angular2-and-feathersjs -> https://berndsgn.ch/observables-with-angular-and-feathersjs/